### PR TITLE
Statically prevent matching the empty string

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -283,6 +283,13 @@ func (l *Lexer) CompileNFA() error {
 			ast++
 		}
 	}
+
+	if mes, err := l.matchesEmptyString(); err != nil {
+		return err
+	} else if mes {
+		return fmt.Errorf("One or more of the supplied patterns match the empty string")
+	}
+
 	return nil
 }
 
@@ -305,5 +312,22 @@ func (l *Lexer) CompileDFA() error {
 	for mid := range dfa.Matches {
 		l.dfaMatches[mid] = mid
 	}
+	if mes, err := l.matchesEmptyString(); err != nil {
+		return err
+	} else if mes {
+		return fmt.Errorf("One or more of the supplied patterns match the empty string")
+	}
 	return nil
+}
+
+func (l *Lexer) matchesEmptyString() (bool, error) {
+	s, err := l.Scanner([]byte(""))
+	if err != nil {
+		return false, err
+	}
+	_, err, _ = s.Next()
+	if ese, is := err.(*machines.EmptyMatchError); ese != nil && is {
+		return true, nil
+	}
+	return false, nil
 }

--- a/lexer.go
+++ b/lexer.go
@@ -287,6 +287,8 @@ func (l *Lexer) CompileNFA() error {
 	if mes, err := l.matchesEmptyString(); err != nil {
 		return err
 	} else if mes {
+		l.program = nil
+		l.nfaMatches = nil
 		return fmt.Errorf("One or more of the supplied patterns match the empty string")
 	}
 
@@ -315,6 +317,8 @@ func (l *Lexer) CompileDFA() error {
 	if mes, err := l.matchesEmptyString(); err != nil {
 		return err
 	} else if mes {
+		l.dfa = nil
+		l.dfaMatches = nil
 		return fmt.Errorf("One or more of the supplied patterns match the empty string")
 	}
 	return nil

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -366,7 +366,7 @@ ddns-update-style none;
 		}
 
 		lex.Add([]byte(`#[^\n]*\n?`), token("COMMENT"))
-		lex.Add([]byte(`([a-z]|[A-Z]|[0-9]|_|\-|\.)*`), token("ID"))
+		lex.Add([]byte(`([a-z]|[A-Z]|[0-9]|_|\-|\.)+`), token("ID"))
 		lex.Add([]byte(`"([^\\"]|(\\.))*"`), token("ID"))
 		lex.Add([]byte("[\n \t]"), skip)
 		for _, lit := range literals {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -513,5 +513,26 @@ func TestPythonStrings(t *testing.T) {
 		}
 		runTest(lexer)
 	}
+}
 
+func TestNoEmptyStrings(t *testing.T) {
+	skip := func(*Scanner, *machines.Match) (interface{}, error) {
+		return nil, nil
+	}
+	lexer := NewLexer()
+	lexer.Add([]byte("(ab|a)*"), skip)
+	{
+		if err := lexer.CompileNFA(); err == nil {
+			t.Fatal("expected error")
+		} else {
+			t.Logf("got expected error: %v", err)
+		}
+	}
+	{
+		if err := lexer.CompileDFA(); err == nil {
+			t.Fatal("expected error")
+		} else {
+			t.Logf("got expected error: %v", err)
+		}
+	}
 }

--- a/machines/machine.go
+++ b/machines/machine.go
@@ -208,8 +208,6 @@ func LexerEngine(program inst.Slice, text []byte) Scanner {
 					EndColumn:   eCol,
 					Bytes:       text[startTC:matchTC],
 				}
-				prevTC = startTC
-				matchPC = -1
 				if matchTC == startTC {
 					err := &EmptyMatchError{
 						MatchID: matchPC,
@@ -219,6 +217,8 @@ func LexerEngine(program inst.Slice, text []byte) Scanner {
 					}
 					return startTC, nil, err, scan
 				}
+				prevTC = startTC
+				matchPC = -1
 				return matchTC, match, nil, scan
 			}
 		}


### PR DESCRIPTION
in response to #22 and #20 this prevents compilation of patterns which match the empty strings. At the moment it does not determine the exact pattern which is responsible for matching the empty string. That would be a good project (and I would welcome the contribution!!).