### PR TITLE
Stream scanning

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -1,7 +1,6 @@
 package lexmachine
 
 import (
-	"bytes"
 	"fmt"
 )
 
@@ -11,52 +10,6 @@ import (
 	"github.com/timtadh/lexmachine/inst"
 	"github.com/timtadh/lexmachine/machines"
 )
-
-// Token is an optional token representation you could use to represent the
-// tokens produced by a lexer built with lexmachine.
-//
-// Here is an example for constructing a lexer Action which turns a
-// machines.Match struct into a token using the scanners Token helper function.
-//
-//     func token(name string, tokenIds map[string]int) lex.Action {
-//         return func(s *lex.Scanner, m *machines.Match) (interface{}, error) {
-//             return s.Token(tokenIds[name], string(m.Bytes), m), nil
-//         }
-//     }
-//
-type Token struct {
-	Type        int
-	Value       interface{}
-	Lexeme      []byte
-	TC          int
-	StartLine   int
-	StartColumn int
-	EndLine     int
-	EndColumn   int
-}
-
-// Equals checks the equality of two tokens ignoring the Value field.
-func (t *Token) Equals(other *Token) bool {
-	if t == nil && other == nil {
-		return true
-	} else if t == nil {
-		return false
-	} else if other == nil {
-		return false
-	}
-	return t.TC == other.TC &&
-		t.StartLine == other.StartLine &&
-		t.StartColumn == other.StartColumn &&
-		t.EndLine == other.EndLine &&
-		t.EndColumn == other.EndColumn &&
-		bytes.Equal(t.Lexeme, other.Lexeme) &&
-		t.Type == other.Type
-}
-
-// String formats the token in a human readable form.
-func (t *Token) String() string {
-	return fmt.Sprintf("%d %q %d (%d, %d)-(%d, %d)", t.Type, t.Value, t.TC, t.StartLine, t.StartColumn, t.EndLine, t.EndColumn)
-}
 
 // An Action is a function which get called when the Scanner finds a match
 // during the lexing process. They turn a low level machines.Match struct into
@@ -82,104 +35,6 @@ type Lexer struct {
 	dfaMatches map[int]int // match_idx -> pat_idx
 	program    inst.Slice
 	dfa        *dfapkg.DFA
-}
-
-// Scanner tokenizes a byte string based on the patterns provided to the lexer
-// object which constructed the scanner. This object works as functional
-// iterator using the Next method.
-//
-// Example
-//
-//     lexer, err := CreateLexer()
-//     if err != nil {
-//         return err
-//     }
-//     scanner, err := lexer.Scanner(someBytes)
-//     if err != nil {
-//         return err
-//     }
-//     for tok, err, eos := scanner.Next(); !eos; tok, err, eos = scanner.Next() {
-//         if err != nil {
-//             return err
-//         }
-//         fmt.Println(tok)
-//     }
-//
-type Scanner struct {
-	lexer   *Lexer
-	matches map[int]int
-	scan    machines.Scanner
-	Text    []byte
-	TC      int
-	pTC     int
-	sLine   int
-	sColumn int
-	eLine   int
-	eColumn int
-}
-
-// Next iterates through the string being scanned returning one token at a time
-// until either an error is encountered or the end of the string is reached.
-// The token is returned by the tok value. An error is indicated by err.
-// Finally, eos (a bool) indicates the End Of String when it returns as true.
-//
-// Example
-//
-//     for tok, err, eos := scanner.Next(); !eos; tok, err, eos = scanner.Next() {
-//         if err != nil {
-//             // handle the error and exit the loop. For example:
-//             return err
-//         }
-//         // do some processing on tok or store it somewhere. eg.
-//         fmt.Println(tok)
-//     }
-//
-// One useful error type which could be returned by Next() is a
-// match.UnconsumedInput which provides the position information for where in
-// the text the scanning failed.
-//
-// For more information on functional iterators see:
-// http://hackthology.com/functional-iteration-in-go.html
-func (s *Scanner) Next() (tok interface{}, err error, eos bool) {
-	var token interface{}
-	for token == nil {
-		tc, match, err, scan := s.scan(s.TC)
-		if scan == nil {
-			return nil, nil, true
-		} else if err != nil {
-			return nil, err, false
-		} else if match == nil {
-			return nil, fmt.Errorf("No match but no error"), false
-		}
-		s.scan = scan
-		s.pTC = s.TC
-		s.TC = tc
-		s.sLine = match.StartLine
-		s.sColumn = match.StartColumn
-		s.eLine = match.EndLine
-		s.eColumn = match.EndColumn
-
-		pattern := s.lexer.patterns[s.matches[match.PC]]
-		token, err = pattern.action(s, match)
-		if err != nil {
-			return nil, err, false
-		}
-	}
-	return token, nil, false
-}
-
-// Token is a helper function for constructing a Token type inside of a Action.
-func (s *Scanner) Token(typ int, value interface{}, m *machines.Match) *Token {
-	return &Token{
-		Type:        typ,
-		Value:       value,
-		Lexeme:      m.Bytes,
-		TC:          m.TC,
-		StartLine:   m.StartLine,
-		StartColumn: m.StartColumn,
-		EndLine:     m.EndLine,
-		EndColumn:   m.EndColumn,
-	}
 }
 
 // NewLexer constructs a new lexer object.

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,105 @@
+package lexmachine
+
+import (
+	"fmt"
+
+	"github.com/timtadh/lexmachine/machines"
+)
+
+// Scanner tokenizes a byte string based on the patterns provided to the lexer
+// object which constructed the scanner. This object works as functional
+// iterator using the Next method.
+//
+// Example
+//
+//     lexer, err := CreateLexer()
+//     if err != nil {
+//         return err
+//     }
+//     scanner, err := lexer.Scanner(someBytes)
+//     if err != nil {
+//         return err
+//     }
+//     for tok, err, eos := scanner.Next(); !eos; tok, err, eos = scanner.Next() {
+//         if err != nil {
+//             return err
+//         }
+//         fmt.Println(tok)
+//     }
+//
+type Scanner struct {
+	lexer   *Lexer
+	matches map[int]int
+	scan    machines.Scanner
+	Text    []byte
+	TC      int
+	pTC     int
+	sLine   int
+	sColumn int
+	eLine   int
+	eColumn int
+}
+
+// Next iterates through the string being scanned returning one token at a time
+// until either an error is encountered or the end of the string is reached.
+// The token is returned by the tok value. An error is indicated by err.
+// Finally, eos (a bool) indicates the End Of String when it returns as true.
+//
+// Example
+//
+//     for tok, err, eos := scanner.Next(); !eos; tok, err, eos = scanner.Next() {
+//         if err != nil {
+//             // handle the error and exit the loop. For example:
+//             return err
+//         }
+//         // do some processing on tok or store it somewhere. eg.
+//         fmt.Println(tok)
+//     }
+//
+// One useful error type which could be returned by Next() is a
+// match.UnconsumedInput which provides the position information for where in
+// the text the scanning failed.
+//
+// For more information on functional iterators see:
+// http://hackthology.com/functional-iteration-in-go.html
+func (s *Scanner) Next() (tok interface{}, err error, eos bool) {
+	var token interface{}
+	for token == nil {
+		tc, match, err, scan := s.scan(s.TC)
+		if scan == nil {
+			return nil, nil, true
+		} else if err != nil {
+			return nil, err, false
+		} else if match == nil {
+			return nil, fmt.Errorf("No match but no error"), false
+		}
+		s.scan = scan
+		s.pTC = s.TC
+		s.TC = tc
+		s.sLine = match.StartLine
+		s.sColumn = match.StartColumn
+		s.eLine = match.EndLine
+		s.eColumn = match.EndColumn
+
+		pattern := s.lexer.patterns[s.matches[match.PC]]
+		token, err = pattern.action(s, match)
+		if err != nil {
+			return nil, err, false
+		}
+	}
+	return token, nil, false
+}
+
+// Token is a helper function for constructing a Token type inside of a Action.
+func (s *Scanner) Token(typ int, value interface{}, m *machines.Match) *Token {
+	return &Token{
+		Type:        typ,
+		Value:       value,
+		Lexeme:      m.Bytes,
+		TC:          m.TC,
+		StartLine:   m.StartLine,
+		StartColumn: m.StartColumn,
+		EndLine:     m.EndLine,
+		EndColumn:   m.EndColumn,
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,1 @@
+package lexmachine

--- a/stream/buffered.go
+++ b/stream/buffered.go
@@ -1,0 +1,189 @@
+package stream
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sync"
+)
+
+type bufferedStream struct {
+	lock    sync.Mutex
+	r       *bufio.Reader
+	tc      int
+	line    int
+	column  int
+	started bool
+	eos     bool
+	buf     []byte
+	err     error
+}
+
+func BufferedStream(r io.Reader) Stream {
+	b := &bufferedStream{
+		r:      bufio.NewReader(r),
+		tc:     -1,
+		line:   1,
+		column: 0,
+	}
+	return b
+}
+
+func (b *bufferedStream) Byte() byte {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if !b.started {
+		panic(fmt.Errorf("Call to Byte() before first call to Advance"))
+	} else if b.eos {
+		panic(fmt.Errorf("Call to Byte() after first call to Advance returned false"))
+	}
+	return b.buf[0]
+}
+
+func (b *bufferedStream) Position() (tc, line, column int) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if !b.started {
+		panic(fmt.Errorf("Call to Position() before first call to Advance"))
+	} else if b.eos {
+		panic(fmt.Errorf("Call to Position() after first call to Advance returned false"))
+	}
+	return b.tc, b.line, b.column
+}
+
+func (b *bufferedStream) Peek(i int) (char byte, has bool) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if b.eos {
+		panic(fmt.Errorf("Call to Byte() after first call to Advance returned false"))
+	}
+	if i <= 0 {
+		panic(fmt.Errorf("Peek() must be called with positive lookahead got %d", i))
+	}
+	// the "cursor" technically starts at -1, this does that adjustment
+	if !b.started {
+		i--
+	}
+	if len(b.buf) >= i+1 {
+		return b.buf[i], true
+	}
+	if !b.read(i) {
+		return 0, false
+	}
+	return b.buf[i], true
+}
+
+func (b *bufferedStream) Started() bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.eos
+}
+
+func (b *bufferedStream) EOS() bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.eos
+}
+
+func (b *bufferedStream) Err() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if !b.started {
+		panic(fmt.Errorf("Call to Err() before first call to Advance"))
+	} else if !b.eos {
+		panic(fmt.Errorf("Call to Err() before call to Advance returned false"))
+	}
+	return b.err
+}
+
+func (b *bufferedStream) Advance(i int) bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.advance(i)
+}
+
+func (b *bufferedStream) advance(i int) bool {
+	if i <= 0 {
+		panic(fmt.Errorf("Advance() must be called with positive move got %d", i))
+	}
+	// the "cursor" technically starts at -1, this does that adjustment
+	if !b.started {
+		b.started = true
+		i--
+		// ensures a read happens even if i==0 when the buf is empty
+		if len(b.buf) <= 0 && !b.read(1) {
+			b.eos = true
+			return false
+		}
+	}
+	i = i - b.trimBuffer(i)
+	if len(b.buf) <= i {
+		if !b.read(i) {
+			b.eos = true
+			return false
+		}
+	}
+	if i > 0 {
+		i = i - b.trimBuffer(i)
+		if i != 0 {
+			panic(fmt.Errorf("i != 0 (i = %d)", i))
+		}
+	}
+	b.trackPos(b.buf[0])
+	return true
+}
+
+// trims the buffer by up i bytes and returns the number of
+// bytes trimmed.
+func (b *bufferedStream) trimBuffer(i int) int {
+	for j := 1; j < i && j < len(b.buf); j++ {
+		b.trackPos(b.buf[j])
+	}
+	if len(b.buf) > i {
+		// we already recorded the position
+		// of b.buf[0]. we need to track all the chars
+		// we are dropping by the skip
+		copy(b.buf[:len(b.buf)-i], b.buf[i:])
+		b.buf = b.buf[:len(b.buf)-i]
+		return i
+	} else {
+		trimmed := len(b.buf)
+		b.buf = b.buf[:0]
+		return trimmed
+	}
+	return 0
+}
+
+// updates the position information for the given character.
+// only call once per character in the stream.
+func (b *bufferedStream) trackPos(char byte) {
+	b.tc++
+	if char == '\n' {
+		b.line++
+		b.column = 0
+	} else {
+		b.column++
+	}
+}
+
+func (b *bufferedStream) read(i int) bool {
+	if b.eos {
+		return false
+	}
+	buf := make([]byte, 4096)
+	for {
+		n, err := b.r.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				// only set err if it is an unexpected error.
+				b.err = err
+			}
+			return false
+		}
+		b.buf = append(b.buf, buf[:n]...)
+		if len(b.buf) >= i+1 {
+			break
+		}
+	}
+	return true
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,0 +1,54 @@
+package stream
+
+// Stream represents a stream of bytes. Its interface is analogous to
+// bufio.Scanner. Here is an example for how to read all the bytes in a stream
+// (and print them one by one):
+//
+//     s := BufferedStream(reader)
+//     for s.Advance(1) {
+//         fmt.Println(s.Byte())
+//     }
+//     if s.Err() != nil {
+//         return s.Err()
+//     }
+//
+type Stream interface {
+
+	// Byte returns the current byte in the stream. This method will panic if
+	// Advance has not been called before this method or Advance has returned
+	// false.
+	Byte() byte
+
+	// Position returns the position of the current byte: text counter, line,
+	// and column. This method will panic if Advance has not been called before
+	// this method or Advance has returned false.
+	Position() (tc, line, column int)
+
+	// Peek returns byte at the current cursor + the lookahead in the stream if
+	// one exists. If lookahead == 0, Peek will panic, if lookahead == 1, it
+	// returns the next byte, and so on. Peek does not advance the cursor. If
+	// there are no further bytes in the stream (or lookahead causes a read
+	// past the end of the stream) Peek returns has == false. You may call this
+	// method before Advance.
+	Peek(lookahead int) (char byte, has bool)
+
+	// Advance moves the cursor i bytes forward in the stream. If there is a
+	// byte to read it returns true. If it reaches the end of the stream (EOS)
+	// it returns false. Advance with i > than number of bytes remaining moves
+	// the cursor to the end of stream (may be less than i) and returns false
+	// (as you cannot read past the end of the stream). Advance must be called
+	// with positive movement otherwise it will panic.
+	Advance(i int) bool
+
+	// Started returns true if at least 1 call to Advance has been made.
+	Started() bool
+
+	// EOS returns true if the stream has reached the end of the stream.
+	EOS() bool
+
+	// Err returns an error if there was an error reading from the underlying
+	// source of the bytes. Panics if called before Advance returns false.
+	// Err() will never return io.EOF (it will be nil in this case -- following
+	// the behavior of ioutil.ReadAll)
+	Err() error
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1,0 +1,290 @@
+package stream
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadFullStream(t *testing.T) {
+	text := "hello world"
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for s.Advance(1) {
+		if err := buf.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != text {
+		t.Fatalf("expect %q got %q", text, buf.String())
+	}
+}
+
+func TestReadEveryOther(t *testing.T) {
+	text := "hello world"
+	expected := "el ol"
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for s.Advance(2) {
+		if err := buf.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != expected {
+		t.Fatalf("expect %q got %q", expected, buf.String())
+	}
+}
+
+func TestReadEvery3(t *testing.T) {
+	text := "hello world"
+	expected := "l r"
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for s.Advance(3) {
+		if err := buf.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != expected {
+		t.Fatalf("expect %q got %q", expected, buf.String())
+	}
+}
+
+func TestPeekTillW(t *testing.T) {
+	text := "hello world"
+	expected := "world"
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if b == 'w' {
+			s.Advance(i)
+			break
+		}
+	}
+	if s.Byte() != 'w' {
+		t.Fatalf("expected w got %v", s.Byte())
+	}
+	for {
+		if err := buf.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+		if !s.Advance(1) {
+			break
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != expected {
+		t.Fatalf("expect %q got %q", expected, buf.String())
+	}
+}
+
+func TestPeekTillWThenL(t *testing.T) {
+	text := "hello world"
+	expected := "ld"
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if b == 'w' {
+			s.Advance(i)
+			break
+		}
+	}
+	if s.Byte() != 'w' {
+		t.Fatalf("expected w got %v", s.Byte())
+	}
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if b == 'l' {
+			s.Advance(i)
+			break
+		}
+	}
+	if s.Byte() != 'l' {
+		t.Fatalf("expected l got %v", s.Byte())
+	}
+	for {
+		if err := buf.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+		if !s.Advance(1) {
+			break
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != expected {
+		t.Fatalf("expect %q got %q", expected, buf.String())
+	}
+}
+
+func TestPeekTillWThenLThenEnd(t *testing.T) {
+	text := "hello world"
+	expected := ""
+	var buf bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if b == 'w' {
+			s.Advance(i)
+			break
+		}
+	}
+	if s.Byte() != 'w' {
+		t.Fatalf("expected w got %v", s.Byte())
+	}
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if b == 'l' {
+			s.Advance(i)
+			break
+		}
+	}
+	if s.Byte() != 'l' {
+		t.Fatalf("expected l got %v", s.Byte())
+	}
+	for i := 1; ; i++ {
+		_, has := s.Peek(i)
+		if !has {
+			s.Advance(i)
+			break
+		}
+	}
+	if !s.EOS() {
+		t.Fatalf("expected EOS")
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if buf.String() != expected {
+		t.Fatalf("expect %q got %q", expected, buf.String())
+	}
+}
+
+func TestPeekThenReadFullStream(t *testing.T) {
+	text := "hello world"
+	var peek bytes.Buffer
+	var read bytes.Buffer
+	s := BufferedStream(bytes.NewBufferString(text))
+	for i := 1; ; i++ {
+		b, has := s.Peek(i)
+		if !has {
+			break
+		}
+		if err := peek.WriteByte(b); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+	}
+	for s.Advance(1) {
+		if err := read.WriteByte(s.Byte()); err != nil {
+			if err != nil {
+				t.Fatalf("err writing %v", err)
+			}
+		}
+	}
+	if s.Err() != nil {
+		t.Fatalf("stream err %v", s.Err())
+	}
+	if peek.String() != text {
+		t.Fatalf("expect %q got %q", text, peek.String())
+	}
+	if read.String() != text {
+		t.Fatalf("expect %q got %q", text, read.String())
+	}
+}
+
+func TestLineColumns(t *testing.T) {
+	text := `b
+	this
+	is
+	wizard
+`
+	var expected = []struct {
+		tc, line, column int
+		char             byte
+	}{
+		{0, 1, 1, 'b'},
+		{1, 2, 0, '\n'},
+		{2, 2, 1, '\t'},
+		{3, 2, 2, 't'},
+		{4, 2, 3, 'h'},
+		{5, 2, 4, 'i'},
+		{6, 2, 5, 's'},
+		{7, 3, 0, '\n'},
+		{8, 3, 1, '\t'},
+		{9, 3, 2, 'i'},
+		{10, 3, 3, 's'},
+		{11, 4, 0, '\n'},
+		{12, 4, 1, '\t'},
+		{13, 4, 2, 'w'},
+		{14, 4, 3, 'i'},
+		{15, 4, 4, 'z'},
+		{16, 4, 5, 'a'},
+		{17, 4, 6, 'r'},
+		{18, 4, 7, 'd'},
+		{19, 5, 0, '\n'},
+	}
+	s := BufferedStream(bytes.NewBufferString(text))
+	// pre-peek everything just to futz with the interior state
+	for i := 1; ; i++ {
+		_, has := s.Peek(i)
+		if !has {
+			break
+		}
+	}
+	for i := 0; s.Advance(1); i++ {
+		tc, line, column := s.Position()
+		char := s.Byte()
+		if char != expected[i].char {
+			t.Fatalf("got %v expected %v", char, expected[i].char)
+		}
+		if tc != expected[i].tc {
+			t.Fatalf("got %v expected %v", tc, expected[i].tc)
+		}
+		if line != expected[i].line {
+			t.Fatalf("got %v expected %v", line, expected[i].line)
+		}
+		if column != expected[i].column {
+			t.Fatalf("got %v expected %v", column, expected[i].column)
+		}
+	}
+}

--- a/token.go
+++ b/token.go
@@ -1,0 +1,52 @@
+package lexmachine
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Token is an optional token representation you could use to represent the
+// tokens produced by a lexer built with lexmachine.
+//
+// Here is an example for constructing a lexer Action which turns a
+// machines.Match struct into a token using the scanners Token helper function.
+//
+//     func token(name string, tokenIds map[string]int) lex.Action {
+//         return func(s *lex.Scanner, m *machines.Match) (interface{}, error) {
+//             return s.Token(tokenIds[name], string(m.Bytes), m), nil
+//         }
+//     }
+//
+type Token struct {
+	Type        int
+	Value       interface{}
+	Lexeme      []byte
+	TC          int
+	StartLine   int
+	StartColumn int
+	EndLine     int
+	EndColumn   int
+}
+
+// Equals checks the equality of two tokens ignoring the Value field.
+func (t *Token) Equals(other *Token) bool {
+	if t == nil && other == nil {
+		return true
+	} else if t == nil {
+		return false
+	} else if other == nil {
+		return false
+	}
+	return t.TC == other.TC &&
+		t.StartLine == other.StartLine &&
+		t.StartColumn == other.StartColumn &&
+		t.EndLine == other.EndLine &&
+		t.EndColumn == other.EndColumn &&
+		bytes.Equal(t.Lexeme, other.Lexeme) &&
+		t.Type == other.Type
+}
+
+// String formats the token in a human readable form.
+func (t *Token) String() string {
+	return fmt.Sprintf("%d %q %d (%d, %d)-(%d, %d)", t.Type, t.Value, t.TC, t.StartLine, t.StartColumn, t.EndLine, t.EndColumn)
+}


### PR DESCRIPTION
This PR will add support for scanning a byte stream instead of needing to read in the entire file. Note, because of how lexical analysis lookahead works in rare cases you *still might need to read in the whole file*. However, this will help many common cases. 

This is not finished.